### PR TITLE
change django github url to point to main branch

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/requirements/base.txt
+++ b/{{cookiecutter.project_slug}}/backend/requirements/base.txt
@@ -1,5 +1,5 @@
 # Master branches
-https://github.com/django/django/archive/master.tar.gz
+https://github.com/django/django/archive/main.tar.gz
 https://github.com/encode/django-rest-framework/archive/master.tar.gz
 
 whitenoise==5.2.0


### PR DESCRIPTION
Django has changed switched their root branch from 'master' to 'main'.