### PR TITLE
Missing `stdin_open: true` on docker-compose.yml file

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     command: python manage.py runserver 0.0.0.0:8000
   react:
     build: ./frontend
+    stdin_open: true
+    tty: true
     volumes:
       - ./frontend:/app
       # One-way volume to use node_modules from inside image


### PR DESCRIPTION
See https://github.com/facebook/create-react-app/issues/8688, and the associated bug #345.